### PR TITLE
[WIP] Unquoted assertions

### DIFF
--- a/test/test_internal.l
+++ b/test/test_internal.l
@@ -7,5 +7,5 @@
     Result ) )
 
 [execute
-  '(assert-kind-of 'List (randomize '(1 2)) "Randomize the list")
-  '(assert-equal '(1 2 3 4) (test-dont-randomize) "Don't randomize the list") ]
+  (assert-kind-of 'List (randomize '(1 2)) "Randomize the list")
+  (assert-equal '(1 2 3 4) (test-dont-randomize) "Don't randomize the list") ]

--- a/test/test_unit.l
+++ b/test/test_unit.l
@@ -1,14 +1,14 @@
 (setq *My_tests_are_order_dependent NIL)
 
 [execute
-  '(assert-equal 0 0 "(assert-equal) should assert equal values")
-  '(assert-nil   NIL "(assert-nil) should assert NIL")
-  '(assert-t     T   "(assert-t) should assert T")
-  '(assert-includes "abc" '("xyzabcdef")  "(assert-includes) should assert includes")
-  '(assert-kind-of  'Flag NIL  "(assert-kind-of) should assert a Flag (NIL)")
-  '(assert-kind-of  'Flag T    "(assert-kind-of) should assert a Flag (T)")
-  '(assert-kind-of  'String "picolisp"  "(assert-kind-of) should assert a String")
-  '(assert-kind-of  'Number 42  "(assert-kind-of) should assert a Number")
-  '(assert-kind-of  'List (1 2 3 4)  "(assert-kind-of) should assert a List")
-  '(assert-kind-of  'Atom 'atom  "(assert-kind-of) should assert a Atom")
-  '(assert-throws   'InternalError '(UnitTestError . "Unit test throws an error") '(throw 'InternalError (cons 'UnitTestError "Unit test throws an error")) "(assert-throws) should assert a thrown error") ]
+  (assert-equal 0 0 "(assert-equal) should assert equal values")
+  (assert-nil   NIL "(assert-nil) should assert NIL")
+  (assert-t     T   "(assert-t) should assert T")
+  (assert-includes "abc" '("xyzabcdef")  "(assert-includes) should assert includes")
+  (assert-kind-of  'Flag NIL  "(assert-kind-of) should assert a Flag (NIL)")
+  (assert-kind-of  'Flag T    "(assert-kind-of) should assert a Flag (T)")
+  (assert-kind-of  'String "picolisp"  "(assert-kind-of) should assert a String")
+  (assert-kind-of  'Number 42  "(assert-kind-of) should assert a Number")
+  (assert-kind-of  'List (1 2 3 4)  "(assert-kind-of) should assert a List")
+  (assert-kind-of  'Atom 'atom  "(assert-kind-of) should assert a Atom")
+  (assert-throws   'InternalError '(UnitTestError . "Unit test throws an error") '(throw 'InternalError (cons 'UnitTestError "Unit test throws an error")) "(assert-throws) should assert a thrown error") ]

--- a/unit.l
+++ b/unit.l
@@ -58,8 +58,8 @@
 
 
 # public
-[de execute @
-  (mapcar eval (randomize (rest) ]
+[de execute Assertions
+  (mapcar '((N) (eval (eval N 1))) (randomize Assertions) ]
 
 [de assert-equal (Expected Result Message)
   (if (= Expected Result)


### PR DESCRIPTION
This change would allow assertions to be written without a `quote`, and passed to `(execute)` unevaluated, but it feels like a hack.

The double-evaluation of assertions allows us to have a list of assertions be quoted or unquoted (i.e: backwards compatible), all for the sake of not breaking existing tests..
